### PR TITLE
Fixed #99 place_basket_order() raises exception for data type of price as float

### DIFF
--- a/alice_blue/alice_blue.py
+++ b/alice_blue/alice_blue.py
@@ -570,7 +570,7 @@ class AliceBlue:
             if i['order_type'] == OrderType.Limit:
                 if "price" not in i:
                     raise TypeError("Each element in orders should have key 'price' if its a limit order ")
-                if isinstance(i['price'], float):
+                if not isinstance(i['price'], float):
                     raise TypeError("Element price in orders should be of type float")
             else:
                 i['price'] = 0.0


### PR DESCRIPTION
Made a correction in the method 'place_basket_order'. It was throwing an error while placing an basket order as the price should be of a float type even if when the price is a float type.